### PR TITLE
Fix MSVC builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'X123M3-256/libImage'
+          path: 'libImage'
       - name: Install vcpkg and packages
         uses: lukka/run-vcpkg@v2
         id: runvcpkg

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(assimp CONFIG REQUIRED)
 add_subdirectory(libImage)
 
 if (MSVC) # assumes vcpkg
-set(EMBREE ${EMBREE_LIBRARIES})
+set(EMBREE embree3)
 set(ASSIMP assimp::assimp)
 set(MATH_LIB "")
 else()
@@ -16,9 +16,10 @@ set(ASSIMP assimp)
 set(MATH_LIB m)
 endif()
 
-include_directories(${PNG_INCLUDE_DIR} ../libImage/src)
+include_directories(${PNG_INCLUDE_DIR} libImage/src)
 link_directories(/usr/local/Cellar/embree/3.6.1/lib)
 link_directories(/usr/local/Cellar/assimp/5.0.0/lib)
+link_directories(${EMBREE_ROOT_DIR}/lib)
 
 add_library(IsoRender STATIC src/vectormath.c src/palette.c src/model.c src/renderer.c src/raytrace.c)
 set_property(TARGET IsoRender PROPERTY C_STANDARD 99)

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -528,6 +528,7 @@ matrix_t camera_inverse=matrix_inverse(camera);
 framebuffer_save_bmp(&framebuffer,"test.bmp");
 //Convert to indexed color
 image_from_framebuffer(image,&framebuffer,&(context->palette));
+free(transformed_lights);
 }
 
 void context_render_view(context_t* context,matrix_t view,image_t* image)


### PR DESCRIPTION
I'm embarrassed to admit previous CI run did not actually compile libIsoRender, but libImage instead.

This is now fixed and fixes builds using `msbuild` too. @spacek531 this should let you use visual studio.